### PR TITLE
Include anchor text as part of the text applied by nonUrlPartsRenderer

### DIFF
--- a/src/components/AnchorifyText.js
+++ b/src/components/AnchorifyText.js
@@ -33,7 +33,7 @@ class AnchorifyText extends React.Component {
       if (React.Children.count(children) === 1) {
         result.push(React.cloneElement(children, {url: match.url, key: keyMatch, match: match}));
       } else {
-        result.push(<a key={keyMatch} href={match.url} target={target}>{match.raw}</a>);
+        result.push(<a key={keyMatch} href={match.url} target={target}>{nonUrlPartsRenderer(match.raw)}</a>);
       }
       last = match.lastIndex;
     });

--- a/test/components/AnchorifyText_spec.js
+++ b/test/components/AnchorifyText_spec.js
@@ -142,8 +142,8 @@ describe('Test of AnchorifyText', () => {
 
     // Assert custom callback is applied
     const customComponents = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'custom-class');
-    const expectedText = ['Hello Google(', ')'];
-    expect(customComponents).to.have.lengthOf(2);
+    const expectedText = ['Hello Google(', 'http://google.com', ')'];
+    expect(customComponents).to.have.lengthOf(3);
     customComponents.forEach((component, index) => {
       expect(component.textContent).to.be.eql(expectedText[index]);
     });


### PR DESCRIPTION
On using the `nonUrlPartsRenderer`, I realized that the anchor text itself should also be given to the nonUrlPartsRenderer. 

If this change is acceptable to you, would you mind releasing another version once merged? 🙏 

cc/ @georgeOsdDev 